### PR TITLE
No pointing to SamuelTrahanNOAA forks.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -32,5 +32,5 @@
     branch = support/HAFS
 [submodule "sorc/hafs_graphics.fd/pygraf"]
     path = sorc/hafs_graphics.fd/pygraf
-    url = https://github.com/SamuelTrahanNOAA/pygraf
-    branch = hafs-ar
+    url = https://github.com/NOAA-GSL/pygraf
+    branch = arfs_dev

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,7 +14,7 @@
     branch = develop
 [submodule "gfdl-tracker"]
     path = sorc/hafs_tracker.fd
-    url = https://github.com/SamuelTrahanNOAA/gfdl-tracker.git
+    url = https://github.com/hafs-community/gfdl-tracker.git
 #   branch = support/HAFS
     branch = support/hafs.v1.1.0
 [submodule "sorc/hafs_gsi.fd"]

--- a/parm/analysis/gsi/hafs_anavinfo.tmp_enkf
+++ b/parm/analysis/gsi/hafs_anavinfo.tmp_enkf
@@ -50,8 +50,8 @@ control_vector_enkf::
  v        _LEV_      0       0.20        -1.0     state    u,v
 !w        _LEV_      0       0.50        -1.0     state    w
 !dz       _LEV_      0       0.50        -1.0     state    dz
- ps         1      0       0.30        -1.0     state    prse
- tsen     _LEV_      0       0.70        -1.0     state    tsen
+!ps        1      0       0.30        -1.0     state    prse
+ t        _LEV_      0       0.70        -1.0     state    tv
  delp     _LEV_      0       0.70        -1.0     state    delp
 !q        _LEV_      1       0.20        -1.0     state    sphum
  q        _LEV_      1       0.20        -1.0     state    q

--- a/parm/hafs_v1p1a.conf
+++ b/parm/hafs_v1p1a.conf
@@ -12,6 +12,8 @@ iend_nest=992,-999
 jend_nest=952,-999
 idim_nest=1440,660
 jdim_nest=1320,660
+delx_nest=0.027,0.009
+dely_nest=0.027,0.009
 
 [grid_mvnest1res]
 istart_nest_mvnest1res=33
@@ -20,6 +22,8 @@ iend_nest_mvnest1res=992
 jend_nest_mvnest1res=952
 idim_nest_mvnest1res=4320
 jdim_nest_mvnest1res=3960
+delx_nest_mvnest1res=0.009
+dely_nest_mvnest1res=0.009
 
 [atm_init]
 # ccpp suites


### PR DESCRIPTION
## Description of changes
Changes:
1. Point to NOAA-GSL pygraf instead of SamuelTrahanNOAA
2. Point to hafs-community gfdl_tracker instead of SamuelTrahanNOAA
3. Sync with top of support/hafs.v1.1.0

With these changes, nothing points to personal forks anymore.

## Issues addressed (optional)
None

## Dependencies (optional)
None.

## Contributors (optional)
None.

## Tests conducted
Reran Steve Weygandt's February 24, 2023 atmospheric river case as a sanity check.
