### PR TITLE
GAEA support and missing diag_table entries

### DIFF
--- a/modulefiles/hafs.gaea_c5.lua
+++ b/modulefiles/hafs.gaea_c5.lua
@@ -68,7 +68,6 @@ end
 
 load("rocoto")
 
---- unload("darshan-runtime")
 unload("cray-libsci")
 
 setenv("CMAKE_C_COMPILER", "cc")

--- a/parm/forecast/globnest/diag_table.tmp
+++ b/parm/forecast/globnest/diag_table.tmp
@@ -370,6 +370,18 @@ ufs.hafs
 # Reflectivity from microphysics
 "gfs_phys", "refl_10cm", "refl_10cm", "fv3_history2d", "all", .false., "none", 2
 
+# NOAH-MP
+"gfs_phys",    "pah_ave",      "pah_ave",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "wa_acc",       "wa_acc",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "pahi",         "pahi",          "fv3_history2d",  "all",  .false.,  "none",  2
+
+# Taken from global-workflow scripts
+"gfs_phys",    "lfrac",        "lfrac",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "rainc",        "rainc",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "ecan_acc",     "ecan_acc",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "edir_acc",     "edir_acc",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "etran_acc",    "etran_acc",     "fv3_history2d",  "all",  .false.,  "none",  2
+
 #Max/Min must be kept in separate files.  Time is controlled by diag_table
 # "dynamics",  "uh25",             "MXUPHL2_5km",     "maxmin2D", "all", max, "none", 2
 # "dynamics",  "uh25",             "MNUPHL2_5km",     "maxmin2D", "all", min, "none", 2

--- a/rocoto/sites/gaea_c5.ent
+++ b/rocoto/sites/gaea_c5.ent
@@ -23,7 +23,7 @@
   <!ENTITY DATM_PREP_RESOURCES "<nodes>1:ppn=1</nodes><envar><name>TOTAL_TASKS</name><value>1</value></envar><envar><name>NCTSK</name><value>1</value></envar><envar><name>OMP_THREADS</name><value>1</value></envar><walltime>00:25:00</walltime>">
   <!ENTITY ATM_PREP_RESOURCES "<nodes>1:ppn=128</nodes><envar><name>TOTAL_TASKS</name><value>18</value></envar><envar><name>NCTSK</name><value>6</value></envar><envar><name>OMP_THREADS</name><value>6</value></envar><walltime>01:30:00</walltime>">
   <!ENTITY OBS_PREP_RESOURCES "<nodes>1:ppn=1:tpp=1</nodes><envar><name>TOTAL_TASKS</name><value>1</value></envar><envar><name>NCTSK</name><value>1</value></envar><envar><name>OMP_THREADS</name><value>1</value></envar><walltime>00:15:00</walltime>">
-  <!ENTITY ATM_IC_STANDARD_RESOURCES "<nodes>3:ppn=60:tpp=1</nodes><envar><name>TOTAL_TASKS</name><value>180</value></envar><envar><name>NCTSK</name><value>60</value></envar><envar><name>OMP_THREADS</name><value>1</value></envar><walltime>00:15:00</walltime>">
+  <!ENTITY ATM_IC_STANDARD_RESOURCES "<nodes>3:ppn=30:tpp=4</nodes><envar><name>TOTAL_TASKS</name><value>90</value></envar><envar><name>NCTSK</name><value>30</value></envar><envar><name>OMP_THREADS</name><value>4</value></envar><walltime>00:30:00</walltime>">
   <!ENTITY ATM_IC_SMALL_RESOURCES "<nodes>1:ppn=60:tpp=1</nodes><envar><name>TOTAL_TASKS</name><value>60</value></envar><envar><name>NCTSK</name><value>60</value></envar><envar><name>OMP_THREADS</name><value>1</value></envar><walltime>00:30:00</walltime>">
   <!ENTITY ATM_LBC_RESOURCES "<nodes>1:ppn=120:tpp=1</nodes><envar><name>TOTAL_TASKS</name><value>120</value></envar><envar><name>NCTSK</name><value>120</value></envar><envar><name>OMP_THREADS</name><value>1</value></envar><walltime>01:30:00</walltime>">
   <!ENTITY ATM_IC_ENS_RESOURCES "<nodes>3:ppn=60:tpp=1</nodes><envar><name>TOTAL_TASKS</name><value>180</value></envar><envar><name>NCTSK</name><value>60</value></envar><envar><name>OMP_THREADS</name><value>1</value></envar><walltime>00:30:00</walltime>">
@@ -37,7 +37,7 @@
   <!ENTITY MERGE_RESOURCES "<nodes>1:ppn=8:tpp=1</nodes><envar><name>TOTAL_TASKS</name><value>8</value></envar><envar><name>NCTSK</name><value>8</value></envar><envar><name>OMP_THREADS</name><value>1</value></envar><walltime>00:10:00</walltime>">
   <!ENTITY ATM_INIT_RESOURCES "<nodes>10:ppn=60:tpp=2</nodes><envar><name>TOTAL_TASKS</name><value>600</value></envar><envar><name>NCTSK</name><value>60</value></envar><envar><name>OMP_THREADS</name><value>2</value></envar><walltime>02:00:00</walltime>">
 
-  <!ENTITY FORECAST_WALLTIME "<walltime>05:59:00</walltime>">
+  <!ENTITY FORECAST_WALLTIME "<walltime>08:59:00</walltime>">
   <!ENTITY FORECAST_OMP "<envar><name>OMP_THREADS</name><value>2</value></envar>">
   <!ENTITY FORECAST_EXTRA "&FORECAST_OMP;&FORECAST_WALLTIME;">
 
@@ -69,12 +69,13 @@
   <!ENTITY FORECAST_RESOURCES_2940PE "<nodes>49:ppn=60:tpp=2</nodes><envar><name>TOTAL_TASKS</name><value>2940</value></envar><envar><name>NCTSK</name><value>60</value></envar>&FORECAST_EXTRA;">
   <!ENTITY FORECAST_RESOURCES_3060PE "<nodes>51:ppn=60:tpp=2</nodes><envar><name>TOTAL_TASKS</name><value>3060</value></envar><envar><name>NCTSK</name><value>60</value></envar>&FORECAST_EXTRA;">
   <!ENTITY FORECAST_RESOURCES_4200PE "<nodes>70:ppn=60:tpp=2</nodes><envar><name>TOTAL_TASKS</name><value>4200</value></envar><envar><name>NCTSK</name><value>60</value></envar>&FORECAST_EXTRA;">
+  <!ENTITY FORECAST_RESOURCES_4320PE "<nodes>72:ppn=60:tpp=2</nodes><envar><name>TOTAL_TASKS</name><value>4320</value></envar><envar><name>NCTSK</name><value>60</value></envar>&FORECAST_EXTRA;">
 
   <!ENTITY FORECAST_RESOURCES_globnest_6x8x10_30x40io2x60 "<nodes>90:ppn=20:tpp=2</nodes><envar><name>TOTAL_TASKS</name><value>1800</value></envar><envar><name>NCTSK</name><value>20</value></envar>&FORECAST_EXTRA;">
 
   <!ENTITY ATM_POST_INLINE_RESOURCES "<nodes>1:ppn=40:tpp=3</nodes><envar><name>TOTAL_TASKS</name><value>40</value></envar><envar><name>NCTSK</name><value>40</value></envar><envar><name>OMP_THREADS</name><value>1</value></envar><walltime>07:59:00</walltime>">
   <!ENTITY ATM_POST_SMALL_RESOURCES "<nodes>1:ppn=40:tpp=3</nodes><envar><name>TOTAL_TASKS</name><value>40</value></envar><envar><name>NCTSK</name><value>40</value></envar><envar><name>OMP_THREADS</name><value>1</value></envar><walltime>07:59:00</walltime>">
-  <!ENTITY ATM_POST_STANDARD_RESOURCES "<nodes>10:ppn=40:tpp=3</nodes><envar><name>TOTAL_TASKS</name><value>400</value></envar><envar><name>NCTSK</name><value>40</value></envar><envar><name>OMP_THREADS</name><value>1</value></envar><walltime>07:59:00</walltime>">
+  <!ENTITY ATM_POST_STANDARD_RESOURCES "<nodes>4:ppn=60:tpp=2</nodes><envar><name>TOTAL_TASKS</name><value>240</value></envar><envar><name>NCTSK</name><value>60</value></envar><envar><name>OMP_THREADS</name><value>1</value></envar><walltime>07:59:00</walltime>">
   <!ENTITY ATM_POST_BIG_RESOURCES "<nodes>10:ppn=40:tpp=3</nodes><envar><name>TOTAL_TASKS</name><value>400</value></envar><envar><name>NCTSK</name><value>40</value></envar><envar><name>OMP_THREADS</name><value>1</value></envar><walltime>07:59:00</walltime>">
 
   <!ENTITY OCN_POST_RESOURCES "<nodes>1:ppn=1:tpp=1</nodes><envar><name>TOTAL_TASKS</name><value>1</value></envar><envar><name>NCTSK</name><value>1</value></envar><envar><name>OMP_THREADS</name><value>1</value></envar><walltime>07:59:00</walltime>">

--- a/sorc/build_forecast.sh
+++ b/sorc/build_forecast.sh
@@ -6,6 +6,8 @@ cwd=$(pwd)
 
 if [[ $target =~ .*c5 ]] ; then target=gaea ; fi
 
+sed 's,.*darshan.*,,g' hafs_forecast.fd/modulefiles/ufs_gaea.intel.lua hafs_forecast.fd/FV3/upp/modulefiles/gaea.lua
+
 cd hafs_forecast.fd/tests
 
 app=HAFSW


### PR DESCRIPTION
## Description of changes

Updates to run the Water in the West 5-day forecasts on GAEA using newer code and additional diag_table entries.

1. The hafs_forecast.fd is updated to the head of the pull request https://github.com/ufs-community/ufs-weather-model/pull/2326
2. Add a few fields to the diag_table that are used by NOAH-MP or output by the global-workflow.
3. Tweak resources for GAEA

## Issues addressed (optional)
N/A

## Dependencies (optional)
We don't need to wait for this to be merged since we already point to this PR for the hafs_forecast.fd.
- https://github.com/ufs-community/ufs-weather-model/pull/2326

## Contributors (optional)
N/A

## Tests conducted
Preliminary testing on GAEA.